### PR TITLE
Add archived gtable package installation and permission update for R 3.6.3 compatibility in Dockerfile

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -63,6 +63,10 @@ RUN chmod +x /usr/local/bin/*
 RUN mkdir /home/R
 ENV R_LIBS_USER="/home/R"
 
+# install necessary R modules
+RUN chmod +x /usr/bin/install2.r
+RUN Rscript -e "install.packages('https://cran.r-project.org/src/contrib/Archive/gtable/gtable_0.3.0.tar.gz', repos = NULL, type = 'source')"
+
 RUN /usr/bin/install2.r --libloc /home/R --error --repos "https://stat.ethz.ch/CRAN/" \
 data.table \
     reshape2 \ 

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,9 +1,15 @@
-# building in ubuntu 20.04
-FROM ubuntu@sha256:b795f8e0caaaacad9859a9a38fe1c78154f8301fdaf0872eaf1520d66d9c0b98 AS builder
+# Unofficial updated version from https://github.com/MikolajKocikowski
+
+# Use a newer Ubuntu because the previous base pinned R 3.6.3, no longer compatible with the required R packages as available on CRAN.
+FROM ubuntu:22.04
+
+# Use bash for all RUN commands
 SHELL ["/bin/bash", "-c"]
 
-ENV CONTAINER_NAME="NGS-AI Seq2scFv"
-ENV CONTAINER_VERSION="0.1"
+# Updated naming for version clarity
+ENV CONTAINER_NAME="NGS-AI_Seq2scFv_MK-fork"
+ENV CONTAINER_VERSION="0.2"
+
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 ENV PATH="/usr/local/bin:$PATH"
@@ -18,22 +24,27 @@ ARG VERSION_PANDAS="2.2.2"
 ARG VERSION_BIOPYTHON="1.84"
 ARG VERSION_CLUSTALO="1.2.4"
 ARG VERSION_BIOAWK="1.0"
+# Pin Python version compatible with the required packages
+ARG VERSION_PYTHON="3.10"
 
 # install some necessary base tools for construction
 RUN apt-get update -y && apt-get install -y unzip wget perl python3 make build-essential libbz2-dev zlib1g-dev liblzma-dev lzma liblzma-dev git libxml2 r-base
 
 # install conda
-RUN echo "Install Bioconda"
-RUN wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda3.sh
-RUN bash miniconda3.sh -b -u -p /usr/miniconda
-ENV export PATH="/usr/miniconda/bin:$PATH"
-RUN conda config --add channels defaults
-RUN conda config --add channels bioconda
-RUN conda config --add channels conda-forge
+ RUN echo "Install Bioconda"
+ RUN wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda3.sh
+ RUN bash miniconda3.sh -b -u -p /usr/miniconda
+ ENV export PATH="/usr/miniconda/bin:$PATH"
+ RUN conda config --add channels defaults
+ RUN conda config --add channels bioconda
+ RUN conda config --add channels conda-forge
+# Accept Conda Terms and Conditions - required after an update.
+ RUN conda config --set plugins.auto_accept_tos yes
 
-# install python packages
-RUN conda install -y pandas=${VERSION_PANDAS} \
-                     biopython=${VERSION_BIOPYTHON} 
+# install python packages - now also defines Python version
+RUN conda install -y python=${VERSION_PYTHON} \
+                     pandas=${VERSION_PANDAS} \
+                     biopython=${VERSION_BIOPYTHON}
 
 # conda installation of other tools
 RUN conda install -y -c bioconda seqkit=${VERSION_SEQKIT} \
@@ -54,7 +65,6 @@ RUN wget --no-check-certificate https://ftp.ncbi.nih.gov/blast/executables/igbla
 
 COPY install2.r /usr/bin/install2.r
 
-
 RUN mkdir /home/seq2scfv
 RUN git clone https://github.com/ngs-ai-org/seq2scfv.git /home/seq2scfv
 RUN cp /home/seq2scfv/bin/* /usr/local/bin/
@@ -63,17 +73,17 @@ RUN chmod +x /usr/local/bin/*
 RUN mkdir /home/R
 ENV R_LIBS_USER="/home/R"
 
-# install necessary R modules
+# Ensure install2.r has executable permissions as it is not in /usr/local/bin/.
 RUN chmod +x /usr/bin/install2.r
-RUN Rscript -e "install.packages('https://cran.r-project.org/src/contrib/Archive/gtable/gtable_0.3.0.tar.gz', repos = NULL, type = 'source')"
 
-RUN /usr/bin/install2.r --libloc /home/R --error --repos "https://stat.ethz.ch/CRAN/" \
-data.table \
-    reshape2 \ 
+# Install packages
+ RUN /usr/bin/install2.r --libloc /home/R --error --repos "https://stat.ethz.ch/CRAN/" \
+    data.table \
+    reshape2 \
     dplyr \
     tidyr \
     ggplot2 \
     gridExtra \
-    stringr 
+    stringr
 
 CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
-# Seq2scFv
+# Seq2scFv - unofficial update
+
+Seq2scFv is a powerful tool for scFv analysis. No pre-built Docker image is publicly available, and the original Dockerfile no longer builds successfully due to pinned tool versions, evolving R packages, and other dependencies.
+
+This repository provides a rebuilt and tested Dockerfile that resolves these issues and incorporates other updates, making the pipeline runnable on modern systems. This ensures the tool can be maintained, extended, and reliably used for current research.
+
+While this setup generally reproduces the functionality of the original pipeline, it is **not identical** to the authors’ environment.
+
+This repository is not affiliated with the original authors or seq2scFv. A related issue and pull request were submitted upstream, but given that the official repo is tied to a published paper, updates there may not be feasible. This repository will maintain any further fixes or improvements. Please be mindful that the original software is provided under a non-commercial license; this repository does not change those terms.
+
+# User Guide
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ files=("${input_dir}/CD160_P0_CCS.filtered.adapt.sizetrim.fasta" \
        "${input_dir}/CD160_P2_CCS.filtered.adapt.sizetrim.fasta" \
        "${input_dir}/CD160_P3_CCS.filtered.adapt.sizetrim.fasta") 
 
-for fastq in "${files[@]}"; do
-  basename=$(basename "$fastq" .filtered.adapt.sizetrim.fasta)
-  uniq_id.py $basename $fastq
+for fasta in "${files[@]}"; do
+  basename=$(basename "$fasta" .filtered.adapt.sizetrim.fasta)
+  uniq_id.py $basename $fasta
 done
 
 cat *correspondence.tsv > merged.nt_correspondence.tsv


### PR DESCRIPTION
This PR addresses two issues with the Dockerfile: (1) a build failure due to an unavailable dependency, gtable, which at the current version (0.3.6) is no longer compatible with R 3.6.3 on CRAN, and (2) a permissions issue preventing the install2.r script from executing properly. To resolve this, the PR:
- Adds a command to install version 0.3.0 of gtable from the CRAN archive, which is compatible with R 3.6.3.
- Updates the script with executable permissions for install2.r to allow it to run as expected.

Additional Notes
A more complex solution using newer gtable version (0.3.5) was tested and can be detailed if desired. Maybe the future builds could benefit from additional version pinning or more granular installation steps for compatibility with evolving CRAN packages. Thanks!